### PR TITLE
Add support for ActiveRecord::Type

### DIFF
--- a/lib/preferences/preference_definition.rb
+++ b/lib/preferences/preference_definition.rb
@@ -10,9 +10,10 @@ module Preferences
       
       @type = args.first ? args.first.to_sym : :boolean
       
+      @klass = "ActiveRecord::Type::#{@type.to_s.classify}".constantize.new
       # Create a column that will be responsible for typecasting
-      @column = ActiveRecord::ConnectionAdapters::Column.new(name.to_s, options[:default], @type == :any ? nil : @type.to_s)
-      
+      @column = ActiveRecord::ConnectionAdapters::Column.new(name.to_s, options[:default], @type == :any ? nil : @klass)
+
       @group_defaults = (options[:group_defaults] || {}).inject({}) do |defaults, (group, default)|
         defaults[group.is_a?(Symbol) ? group.to_s : group] = type_cast(default)
         defaults
@@ -39,7 +40,7 @@ module Preferences
     # This uses ActiveRecord's typecast functionality so the same rules for
     # typecasting a model's columns apply here.
     def type_cast(value)
-      @type == :any ? value : @column.type_cast(value)
+      @type == :any ? value : @column.type_cast_from_database(value)
     end
     
     # Typecasts the value to true/false depending on the type of preference


### PR DESCRIPTION
Rails 4.2 introduces types for conversions. 
http://technology.customink.com/blog/2015/01/06/activerecord-42s-type-casting/
